### PR TITLE
Reverting dominodatalab module

### DIFF
--- a/benchmark/jsonresultset/jsonresultset_test.go
+++ b/benchmark/jsonresultset/jsonresultset_test.go
@@ -19,7 +19,7 @@ import (
 	"strconv"
 	"strings"
 
-	sf "github.com/dominodatalab/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake"
 )
 
 func TestJsonResultSet(t *testing.T) {

--- a/benchmark/largesetresult/largesetresult_test.go
+++ b/benchmark/largesetresult/largesetresult_test.go
@@ -18,7 +18,7 @@ import (
 
 	"strconv"
 
-	sf "github.com/dominodatalab/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake"
 )
 
 func TestLargeResultSet(t *testing.T) {

--- a/cmd/externalbrowser/externalbrowser.go
+++ b/cmd/externalbrowser/externalbrowser.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strconv"
 
-	sf "github.com/dominodatalab/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake"
 )
 
 // getDSN constructs a DSN based on the test connection parameters

--- a/cmd/keepalive/keepalive.go
+++ b/cmd/keepalive/keepalive.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"time"
 
-	sf "github.com/dominodatalab/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake"
 )
 
 // getDSN constructs a DSN based on the test connection parameters

--- a/cmd/logger/logger.go
+++ b/cmd/logger/logger.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	rlog "github.com/sirupsen/logrus"
-	sf "github.com/dominodatalab/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake"
 	"log"
 	"strings"
 )

--- a/cmd/noconnpool/noconnpool.go
+++ b/cmd/noconnpool/noconnpool.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"sync"
 
-	sf "github.com/dominodatalab/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake"
 )
 
 // getDSN constructs a DSN based on the test connection parameters

--- a/cmd/oauth/oauth.go
+++ b/cmd/oauth/oauth.go
@@ -12,7 +12,7 @@ import (
 	"net/url"
 	"os"
 
-	_ "github.com/dominodatalab/gosnowflake"
+	_ "github.com/snowflakedb/gosnowflake"
 )
 
 func main() {

--- a/cmd/select1/select1.go
+++ b/cmd/select1/select1.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"strconv"
 
-	sf "github.com/dominodatalab/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake"
 )
 
 // getDSN constructs a DSN based on the test connection parameters

--- a/cmd/selectmany/selectmany.go
+++ b/cmd/selectmany/selectmany.go
@@ -16,7 +16,7 @@ import (
 
 	"runtime/debug"
 
-	sf "github.com/dominodatalab/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake"
 )
 
 var (

--- a/cmd/showparam/showparam.go
+++ b/cmd/showparam/showparam.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"strconv"
 
-	sf "github.com/dominodatalab/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake"
 )
 
 // getDSN constructs a DSN based on the test connection parameters

--- a/cmd/verifycert/verifycert.go
+++ b/cmd/verifycert/verifycert.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"time"
 
-	sf "github.com/dominodatalab/gosnowflake"
+	sf "github.com/snowflakedb/gosnowflake"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dominodatalab/gosnowflake
+module github.com/snowflakedb/gosnowflake
 
 go 1.16
 


### PR DESCRIPTION
### Description
The fork was changed to contain dominodatalab as the name of the module. Reverting that back to open PR against gosnowflake's master branch

### Checklist
- [ ] Code compiles correctly
- [ ] Run ``make fmt`` to fix inconsistent formats
- [ ] Run ``make lint`` to get lint errors and fix all of them
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
